### PR TITLE
feat: soportar componentes interactivos en plantillas

### DIFF
--- a/app/(main)/chat/whatsapp/service/chatServices.ts
+++ b/app/(main)/chat/whatsapp/service/chatServices.ts
@@ -1,4 +1,11 @@
 import { WhatsAppResponseSendMessage } from "@/shared/models/conversation/messages.model"
+import {
+  TemplateBodyComponent,
+  TemplateButton,
+  TemplateButtonType,
+  TemplateButtonsComponent,
+  TemplateInteractiveComponent
+} from "@/shared/models"
 import { axiosInstance } from "@/shared/instances/axios-instance"
 
 interface Agent {
@@ -12,6 +19,20 @@ interface Group {
   id: string;
   name: string;
 }
+
+const buttonTypeToSubtype: Record<TemplateButtonType, "quick_reply" | "url" | "phone_number"> = {
+  QUICK_REPLY: "quick_reply",
+  URL: "url",
+  PHONE_NUMBER: "phone_number"
+}
+
+const isBodyComponent = (
+  component: TemplateInteractiveComponent
+): component is TemplateBodyComponent => component?.type === "body"
+
+const isButtonsComponent = (
+  component: TemplateInteractiveComponent
+): component is TemplateButtonsComponent => component?.type === "buttons" && Array.isArray(component.buttons)
 
 /**
  * Envía un mensaje simple (texto) a través de la API de WhatsApp.
@@ -176,13 +197,17 @@ export async function sendTemplateMessage (
     console.log(`[DEBUG] Información de plantilla: mediaUrl=${mediaUrl}, mediaType=${mediaType}`);
     
     // Crear la estructura de datos base para el mensaje
+    const templateLanguageCode = String(
+      templateData.language || templateData.languageTemplateWhatsapp || 'es'
+    ).toLowerCase();
+
     const messageData: any = {
       messaging_product: "whatsapp",
       to: recipientPhone,
       type: "template",
       template: {
         name: finalTemplateName,
-        language: { code: "es" }
+        language: { code: templateLanguageCode }
       }
     };
     
@@ -214,52 +239,141 @@ export async function sendTemplateMessage (
       isCorrectMediaType
     });
     
-    // Si es plantilla multimedia, agregar los componentes necesarios
-    if (isMultimedia && isMediaUrlValid && isHttpsUrl) {
-      console.log(`[DEBUG] Agregando componentes multimedia para plantilla: ${finalTemplateName}`);
-      
-      // Construir el header según el tipo de media del backend
-      let headerParameter;
-      if (mediaType === 'image') {
-        headerParameter = {
-          type: "image",
-          image: { link: mediaUrl }
-        };
-      } else if (mediaType === 'video') {
-        headerParameter = {
-          type: "video",
-          video: { link: mediaUrl }
-        };
-      } else if (mediaType === 'document') {
-        headerParameter = {
-          type: "document", 
-          document: { link: mediaUrl }
-        };
-      } else {
-        // Fallback para tipos no reconocidos, asumir imagen
-        console.warn(`[WARN] Tipo de media no reconocido: ${mediaType}, usando image como fallback`);
-        headerParameter = {
-          type: "image",
-          image: { link: mediaUrl }
-        };
-      }
-      
-      messageData.template.components = [
-        {
+    const outgoingComponents: any[] = [];
+
+    if (isMultimedia) {
+      if (isMediaUrlValid && isHttpsUrl) {
+        console.log(`[DEBUG] Agregando header multimedia para plantilla: ${finalTemplateName}`);
+
+        let headerParameter;
+        if (mediaType === 'image') {
+          headerParameter = {
+            type: "image",
+            image: { link: mediaUrl }
+          };
+        } else if (mediaType === 'video') {
+          headerParameter = {
+            type: "video",
+            video: { link: mediaUrl }
+          };
+        } else if (mediaType === 'document') {
+          headerParameter = {
+            type: "document",
+            document: { link: mediaUrl }
+          };
+        } else if (mediaType === 'audio') {
+          headerParameter = {
+            type: "audio",
+            audio: { link: mediaUrl }
+          };
+        } else {
+          console.warn(`[WARN] Tipo de media no reconocido: ${mediaType}, usando image como fallback`);
+          headerParameter = {
+            type: "image",
+            image: { link: mediaUrl }
+          };
+        }
+
+        outgoingComponents.push({
           type: "header",
           parameters: [headerParameter]
+        });
+      } else {
+        console.error(`[ERROR] Plantilla marcada como multimedia pero falta información válida:`, {
+          mediaUrl,
+          mediaType,
+          isMediaUrlValid,
+          isHttpsUrl
+        });
+      }
+    }
+
+    const backendComponents: TemplateInteractiveComponent[] = Array.isArray(templateData.components)
+      ? (templateData.components as TemplateInteractiveComponent[])
+      : [];
+
+    const bodyComponent = backendComponents.find(isBodyComponent);
+
+    if (bodyComponent) {
+      const bodyParameters: any[] = [];
+
+      if (Array.isArray(bodyComponent.parameters) && bodyComponent.parameters.length) {
+        bodyComponent.parameters.forEach((parameter) => {
+          if (parameter.type === 'text' && 'text' in parameter && parameter.text) {
+            bodyParameters.push({ type: 'text', text: parameter.text });
+          }
+
+          if (parameter.type === 'payload' && 'payload' in parameter && parameter.payload) {
+            bodyParameters.push({ type: 'payload', payload: parameter.payload });
+          }
+        });
+      } else if (bodyComponent.text) {
+        bodyParameters.push({ type: 'text', text: bodyComponent.text });
+      }
+
+      if (bodyParameters.length) {
+        outgoingComponents.push({
+          type: 'body',
+          parameters: bodyParameters
+        });
+      }
+    }
+
+    const buttonsComponent = backendComponents.find(isButtonsComponent);
+
+    if (buttonsComponent?.buttons?.length) {
+      buttonsComponent.buttons.forEach((button: TemplateButton, index: number) => {
+        if (!button?.type || !button.text) {
+          return;
         }
-      ];
-      
-      console.log(`[DEBUG] Componentes agregados: ${JSON.stringify(messageData.template.components)}`);
-    } else if (isMultimedia) {
-      // Si se identifica como multimedia pero falta información, alertar
-      console.error(`[ERROR] Plantilla marcada como multimedia pero falta información válida:`, {
-        mediaUrl,
-        mediaType,
-        isMediaUrlValid,
-        isHttpsUrl
+
+        const subtype = buttonTypeToSubtype[button.type];
+        if (!subtype) {
+          console.warn(`[WARN] Tipo de botón no soportado: ${button.type}`);
+          return;
+        }
+
+        const buttonParameters: any[] = [];
+
+        if (button.type === 'QUICK_REPLY') {
+          const payloadValue = button.payload?.trim() || button.text.trim();
+          if (payloadValue) {
+            buttonParameters.push({ type: 'payload', payload: payloadValue });
+          }
+        } else if (button.type === 'URL') {
+          const urlValue = button.url?.trim();
+          if (urlValue) {
+            buttonParameters.push({ type: 'text', text: urlValue });
+          }
+        } else if (button.type === 'PHONE_NUMBER') {
+          const phoneValue = button.phoneNumber?.trim();
+          if (phoneValue) {
+            buttonParameters.push({ type: 'text', text: phoneValue });
+          }
+        }
+
+        const graphButton: any = {
+          type: 'button',
+          sub_type: subtype,
+          index: String(index)
+        };
+
+        if (buttonParameters.length) {
+          graphButton.parameters = buttonParameters;
+        }
+
+        outgoingComponents.push(graphButton);
       });
+    }
+
+    const hasSectionsComponent = backendComponents.some((component) => component?.type === 'sections');
+    if (hasSectionsComponent) {
+      console.warn('[WARN] Se detectaron secciones en la plantilla, pero las listas no son compatibles con mensajes de plantilla de la Graph API.');
+    }
+
+    if (outgoingComponents.length) {
+      messageData.template.components = outgoingComponents;
+      console.log(`[DEBUG] Componentes finales a enviar: ${JSON.stringify(outgoingComponents)}`);
     }
 
     const response = await fetch(apiUrl, {

--- a/app/(main)/template/form/[[...id]]/page.tsx
+++ b/app/(main)/template/form/[[...id]]/page.tsx
@@ -1,8 +1,16 @@
 "use client"
 import { useToast } from "@/shared/context/toast/toastContext"
 import { usePush } from "@/shared/hooks/usePush"
-import { TemplateModel } from "@/shared/models"
-import { MultimediaTemplateModel, TemplateMediaType } from "@/shared/models/template/multimedia-template.model"
+import {
+  MultimediaTemplateModel,
+  TemplateButton,
+  TemplateButtonType,
+  TemplateInteractiveComponent,
+  TemplateMediaType,
+  TemplateModel,
+  TemplateSection,
+  TemplateSectionRow
+} from "@/shared/models"
 import { ADMIN_ROUTES } from "@/shared/routes/admin.routes"
 import {
   TemplateService as _template
@@ -24,6 +32,419 @@ import { SelectButton } from "primereact/selectbutton"
 import { TabPanel, TabView } from "primereact/tabview"
 import { useEffect, useRef, useState } from "react"
 import { Controller, SubmitHandler, useForm } from "react-hook-form"
+
+const createId = () => Math.random().toString(36).slice(2, 10)
+
+const buttonTypeOptions = [
+  { label: "Respuesta rápida", value: "QUICK_REPLY" as TemplateButtonType },
+  { label: "Abrir URL", value: "URL" as TemplateButtonType },
+  { label: "Llamar", value: "PHONE_NUMBER" as TemplateButtonType }
+]
+
+type EditableButtonField = "type" | "text" | "payload" | "url" | "phoneNumber"
+type EditableRowField = "title" | "description"
+
+const createEmptyButton = (): TemplateButton => ({
+  id: createId(),
+  type: "QUICK_REPLY",
+  text: "",
+  payload: ""
+})
+
+const createEmptySection = (): TemplateSection => ({
+  id: createId(),
+  title: "",
+  rows: []
+})
+
+const createEmptySectionRow = (): TemplateSectionRow => ({
+  id: createId(),
+  title: "",
+  description: ""
+})
+
+const updateButtonList = (
+  buttons: TemplateButton[],
+  index: number,
+  field: EditableButtonField,
+  value: string
+): TemplateButton[] =>
+  buttons.map((button, idx) => {
+    if (idx !== index) return button
+
+    if (field === "type") {
+      const nextType = value as TemplateButtonType
+      return {
+        ...button,
+        type: nextType,
+        payload: nextType === "QUICK_REPLY" ? button.payload ?? "" : undefined,
+        url: nextType === "URL" ? button.url ?? "" : undefined,
+        phoneNumber: nextType === "PHONE_NUMBER" ? button.phoneNumber ?? "" : undefined
+      }
+    }
+
+    if (field === "text") {
+      return { ...button, text: value }
+    }
+
+    if (field === "payload") {
+      return { ...button, payload: value }
+    }
+
+    if (field === "url") {
+      return { ...button, url: value }
+    }
+
+    if (field === "phoneNumber") {
+      return { ...button, phoneNumber: value }
+    }
+
+    return button
+  })
+
+const updateSectionTitleList = (sections: TemplateSection[], index: number, value: string): TemplateSection[] =>
+  sections.map((section, idx) => (idx === index ? { ...section, title: value } : section))
+
+const addRowToSectionList = (sections: TemplateSection[], index: number): TemplateSection[] =>
+  sections.map((section, idx) =>
+    idx === index ? { ...section, rows: [...section.rows, createEmptySectionRow()] } : section
+  )
+
+const removeRowFromSectionList = (
+  sections: TemplateSection[],
+  sectionIndex: number,
+  rowIndex: number
+): TemplateSection[] =>
+  sections.map((section, idx) =>
+    idx === sectionIndex
+      ? { ...section, rows: section.rows.filter((_, rIdx) => rIdx !== rowIndex) }
+      : section
+  )
+
+const updateRowInSectionList = (
+  sections: TemplateSection[],
+  sectionIndex: number,
+  rowIndex: number,
+  field: EditableRowField,
+  value: string
+): TemplateSection[] =>
+  sections.map((section, idx) => {
+    if (idx !== sectionIndex) return section
+
+    return {
+      ...section,
+      rows: section.rows.map((row, rIdx) => {
+        if (rIdx !== rowIndex) return row
+
+        if (field === "title") {
+          return { ...row, title: value }
+        }
+
+        if (field === "description") {
+          return { ...row, description: value }
+        }
+
+        return row
+      })
+    }
+  })
+
+const sanitizeButtons = (buttons: TemplateButton[]): TemplateButton[] =>
+  buttons
+    .map(({ type, text, payload, url, phoneNumber }) => ({
+      type,
+      text: text.trim(),
+      payload: payload?.trim() || undefined,
+      url: url?.trim() || undefined,
+      phoneNumber: phoneNumber?.trim() || undefined
+    }))
+    .filter((button) => button.text.length > 0)
+
+const sanitizeSections = (sections: TemplateSection[]): TemplateSection[] =>
+  sections
+    .map(({ title, rows }) => ({
+      title: title.trim(),
+      rows: rows
+        .map(({ title: rowTitle, description }) => ({
+          title: rowTitle.trim(),
+          description: description?.trim() || undefined
+        }))
+        .filter((row) => row.title.length > 0)
+    }))
+    .filter((section) => section.title.length > 0 && section.rows.length > 0)
+
+const createBodyComponent = (text: string) => ({
+  type: "body" as const,
+  text,
+  parameters: [{ type: "text" as const, text }]
+})
+
+const validateButtons = (buttons: TemplateButton[]): string | null => {
+  for (const button of buttons) {
+    if (!button.text || !button.text.trim()) {
+      return "Cada botón debe tener un texto visible"
+    }
+
+    if (button.type === "URL") {
+      if (!button.url || !button.url.trim()) {
+        return "Los botones de tipo URL deben incluir un enlace"
+      }
+      const normalizedUrl = button.url.trim()
+      if (!/^https?:\/\//i.test(normalizedUrl)) {
+        return "El enlace de un botón debe iniciar con http:// o https://"
+      }
+    }
+
+    if (button.type === "PHONE_NUMBER") {
+      if (!button.phoneNumber || !button.phoneNumber.trim()) {
+        return "Los botones de llamada deben incluir un número telefónico"
+      }
+      const normalizedPhone = button.phoneNumber.replace(/[^0-9+]/g, "")
+      if (normalizedPhone.length < 5) {
+        return "El número telefónico del botón debe ser válido"
+      }
+    }
+  }
+
+  return null
+}
+
+const validateSections = (sections: TemplateSection[]): string | null => {
+  for (const section of sections) {
+    if (!section.title || !section.title.trim()) {
+      return "Cada sección debe tener un título"
+    }
+
+    if (!section.rows || section.rows.length === 0) {
+      return "Cada sección debe tener al menos un elemento"
+    }
+
+    for (const row of section.rows) {
+      if (!row.title || !row.title.trim()) {
+        return "Cada elemento dentro de una sección debe tener un título"
+      }
+    }
+  }
+
+  return null
+}
+
+interface ButtonsEditorProps {
+  title: string;
+  description?: string;
+  buttons: TemplateButton[];
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+  onChange: (index: number, field: EditableButtonField, value: string) => void;
+}
+
+const ButtonsEditor = ({ title, description, buttons, onAdd, onRemove, onChange }: ButtonsEditorProps) => (
+  <div className="field mb-4">
+    <div className="flex justify-content-between align-items-center mb-2">
+      <div>
+        <label className="font-medium text-900 block">{title}</label>
+        {description && <small className="text-600">{description}</small>}
+      </div>
+      <Button type="button" icon="pi pi-plus" label="Agregar botón" outlined onClick={onAdd} />
+    </div>
+
+    {buttons.length === 0 && (
+      <small className="block text-600">Aún no se han configurado botones.</small>
+    )}
+
+    {buttons.map((button, index) => (
+      <Card key={button.id ?? index} className="mb-3">
+        <div className="flex justify-content-between align-items-center mb-3">
+          <span className="font-semibold text-900">Botón {index + 1}</span>
+          <Button
+            type="button"
+            icon="pi pi-trash"
+            severity="danger"
+            outlined
+            onClick={() => onRemove(index)}
+          />
+        </div>
+
+        <div className="grid">
+          <div className="col-12 md:col-4">
+            <label className="font-medium text-900 block mb-2">Tipo</label>
+            <Dropdown
+              value={button.type}
+              options={buttonTypeOptions}
+              optionLabel="label"
+              optionValue="value"
+              onChange={(e) => onChange(index, "type", e.value)}
+              className="w-full"
+            />
+          </div>
+
+          <div className="col-12 md:col-4">
+            <label className="font-medium text-900 block mb-2">Texto visible</label>
+            <InputText
+              value={button.text}
+              onChange={(e) => onChange(index, "text", e.target.value)}
+              placeholder="Texto del botón"
+              className="w-full"
+            />
+          </div>
+
+          {button.type === "QUICK_REPLY" && (
+            <div className="col-12 md:col-4">
+              <label className="font-medium text-900 block mb-2">Payload (opcional)</label>
+              <InputText
+                value={button.payload ?? ""}
+                onChange={(e) => onChange(index, "payload", e.target.value)}
+                placeholder="Identificador de la respuesta"
+                className="w-full"
+              />
+            </div>
+          )}
+
+          {button.type === "URL" && (
+            <div className="col-12 md:col-4">
+              <label className="font-medium text-900 block mb-2">URL</label>
+              <InputText
+                value={button.url ?? ""}
+                onChange={(e) => onChange(index, "url", e.target.value)}
+                placeholder="https://..."
+                className="w-full"
+              />
+            </div>
+          )}
+
+          {button.type === "PHONE_NUMBER" && (
+            <div className="col-12 md:col-4">
+              <label className="font-medium text-900 block mb-2">Número telefónico</label>
+              <InputText
+                value={button.phoneNumber ?? ""}
+                onChange={(e) => onChange(index, "phoneNumber", e.target.value)}
+                placeholder="Ej: +573001112233"
+                className="w-full"
+              />
+            </div>
+          )}
+        </div>
+      </Card>
+    ))}
+  </div>
+)
+
+interface SectionsEditorProps {
+  title: string;
+  description?: string;
+  sections: TemplateSection[];
+  onAddSection: () => void;
+  onRemoveSection: (index: number) => void;
+  onSectionTitleChange: (index: number, value: string) => void;
+  onAddRow: (sectionIndex: number) => void;
+  onRemoveRow: (sectionIndex: number, rowIndex: number) => void;
+  onRowChange: (sectionIndex: number, rowIndex: number, field: EditableRowField, value: string) => void;
+}
+
+const SectionsEditor = ({
+  title,
+  description,
+  sections,
+  onAddSection,
+  onRemoveSection,
+  onSectionTitleChange,
+  onAddRow,
+  onRemoveRow,
+  onRowChange
+}: SectionsEditorProps) => (
+  <div className="field mb-4">
+    <div className="flex justify-content-between align-items-center mb-2">
+      <div>
+        <label className="font-medium text-900 block">{title}</label>
+        {description && <small className="text-600">{description}</small>}
+      </div>
+      <Button type="button" icon="pi pi-plus" label="Agregar sección" outlined onClick={onAddSection} />
+    </div>
+
+    {sections.length === 0 && (
+      <small className="block text-600">Aún no se han configurado secciones.</small>
+    )}
+
+    {sections.map((section, sectionIndex) => (
+      <Card key={section.id ?? sectionIndex} className="mb-3">
+        <div className="flex justify-content-between align-items-center mb-3">
+          <span className="font-semibold text-900">Sección {sectionIndex + 1}</span>
+          <Button
+            type="button"
+            icon="pi pi-trash"
+            severity="danger"
+            outlined
+            onClick={() => onRemoveSection(sectionIndex)}
+          />
+        </div>
+
+        <div className="field mb-3">
+          <label className="font-medium text-900 block mb-2">Título de la sección</label>
+          <InputText
+            value={section.title}
+            onChange={(e) => onSectionTitleChange(sectionIndex, e.target.value)}
+            placeholder="Título visible en la lista"
+            className="w-full"
+          />
+        </div>
+
+        <div className="flex justify-content-between align-items-center mb-2">
+          <span className="font-medium text-900">Elementos</span>
+          <Button
+            type="button"
+            icon="pi pi-plus"
+            label="Agregar elemento"
+            outlined
+            onClick={() => onAddRow(sectionIndex)}
+          />
+        </div>
+
+        {section.rows.length === 0 && (
+          <small className="block text-600">Agregue al menos un elemento a la sección.</small>
+        )}
+
+        {section.rows.map((row, rowIndex) => (
+          <Card key={row.id ?? rowIndex} className="mb-3 surface-100">
+            <div className="flex justify-content-between align-items-center mb-3">
+              <span className="font-medium text-900">Elemento {rowIndex + 1}</span>
+              <Button
+                type="button"
+                icon="pi pi-times"
+                severity="secondary"
+                outlined
+                onClick={() => onRemoveRow(sectionIndex, rowIndex)}
+              />
+            </div>
+
+            <div className="grid">
+              <div className="col-12 md:col-6">
+                <label className="font-medium text-900 block mb-2">Título</label>
+                <InputText
+                  value={row.title}
+                  onChange={(e) => onRowChange(sectionIndex, rowIndex, "title", e.target.value)}
+                  placeholder="Texto del elemento"
+                  className="w-full"
+                />
+              </div>
+
+              <div className="col-12 md:col-6">
+                <label className="font-medium text-900 block mb-2">Descripción (opcional)</label>
+                <InputTextarea
+                  value={row.description ?? ""}
+                  onChange={(e) => onRowChange(sectionIndex, rowIndex, "description", e.target.value)}
+                  rows={2}
+                  autoResize
+                  placeholder="Detalle adicional"
+                  className="w-full"
+                />
+              </div>
+            </div>
+          </Card>
+        ))}
+      </Card>
+    ))}
+  </div>
+)
 
 /**
  * Componente para crear y editar plantillas de WhatsApp
@@ -52,6 +473,10 @@ const TemplateForm = () => {
   const [mediaType, setMediaType] = useState(TemplateMediaType.NONE)
   const [mediaUrl, setMediaUrl] = useState('')
   const [mediaFileName, setMediaFileName] = useState('')
+  const [basicButtons, setBasicButtons] = useState<TemplateButton[]>([])
+  const [basicSections, setBasicSections] = useState<TemplateSection[]>([])
+  const [multimediaButtons, setMultimediaButtons] = useState<TemplateButton[]>([])
+  const [multimediaSections, setMultimediaSections] = useState<TemplateSection[]>([])
   // const [componentsLoaded, setComponentsLoaded] = useState(false) // No utilizado actualmente
   
   // Controla la inicialización segura de componentes
@@ -74,6 +499,51 @@ const TemplateForm = () => {
     { label: 'Documento', value: TemplateMediaType.DOCUMENT },
     { label: 'Audio', value: TemplateMediaType.AUDIO }
   ]
+
+  const addBasicButton = () => setBasicButtons((prev) => [...prev, createEmptyButton()])
+  const removeBasicButton = (index: number) =>
+    setBasicButtons((prev) => prev.filter((_, idx) => idx !== index))
+  const updateBasicButton = (index: number, field: EditableButtonField, value: string) =>
+    setBasicButtons((prev) => updateButtonList(prev, index, field, value))
+
+  const addBasicSection = () => setBasicSections((prev) => [...prev, createEmptySection()])
+  const removeBasicSection = (index: number) =>
+    setBasicSections((prev) => prev.filter((_, idx) => idx !== index))
+  const updateBasicSectionTitle = (index: number, value: string) =>
+    setBasicSections((prev) => updateSectionTitleList(prev, index, value))
+  const addRowToBasicSection = (sectionIndex: number) =>
+    setBasicSections((prev) => addRowToSectionList(prev, sectionIndex))
+  const removeRowFromBasicSection = (sectionIndex: number, rowIndex: number) =>
+    setBasicSections((prev) => removeRowFromSectionList(prev, sectionIndex, rowIndex))
+  const updateBasicSectionRow = (
+    sectionIndex: number,
+    rowIndex: number,
+    field: EditableRowField,
+    value: string
+  ) => setBasicSections((prev) => updateRowInSectionList(prev, sectionIndex, rowIndex, field, value))
+
+  const addMultimediaButton = () => setMultimediaButtons((prev) => [...prev, createEmptyButton()])
+  const removeMultimediaButton = (index: number) =>
+    setMultimediaButtons((prev) => prev.filter((_, idx) => idx !== index))
+  const updateMultimediaButton = (index: number, field: EditableButtonField, value: string) =>
+    setMultimediaButtons((prev) => updateButtonList(prev, index, field, value))
+
+  const addMultimediaSection = () => setMultimediaSections((prev) => [...prev, createEmptySection()])
+  const removeMultimediaSection = (index: number) =>
+    setMultimediaSections((prev) => prev.filter((_, idx) => idx !== index))
+  const updateMultimediaSectionTitle = (index: number, value: string) =>
+    setMultimediaSections((prev) => updateSectionTitleList(prev, index, value))
+  const addRowToMultimediaSection = (sectionIndex: number) =>
+    setMultimediaSections((prev) => addRowToSectionList(prev, sectionIndex))
+  const removeRowFromMultimediaSection = (sectionIndex: number, rowIndex: number) =>
+    setMultimediaSections((prev) => removeRowFromSectionList(prev, sectionIndex, rowIndex))
+  const updateMultimediaSectionRow = (
+    sectionIndex: number,
+    rowIndex: number,
+    field: EditableRowField,
+    value: string
+  ) =>
+    setMultimediaSections((prev) => updateRowInSectionList(prev, sectionIndex, rowIndex, field, value))
   
   const fileUploadRef = useRef<FileUpload | null>(null)
   const { showSuccess, showError } = useToast()
@@ -100,13 +570,41 @@ const TemplateForm = () => {
    * Manejador para envío de plantilla básica de texto
    */
   const onSubmit: SubmitHandler<TemplateModel> = async (data) => {
-    // Usar la empresa del token del usuario
+    const buttonValidationError = validateButtons(basicButtons)
+    if (buttonValidationError) {
+      showError(buttonValidationError)
+      return
+    }
+
+    const sectionsValidationError = validateSections(basicSections)
+    if (sectionsValidationError) {
+      showError(sectionsValidationError)
+      return
+    }
+
+    const components: TemplateInteractiveComponent[] = []
+    const trimmedText = data.textTemplate?.trim()
+
+    if (trimmedText) {
+      components.push(createBodyComponent(trimmedText))
+    }
+
+    const normalizedButtons = sanitizeButtons(basicButtons)
+    if (normalizedButtons.length) {
+      components.push({ type: "buttons", buttons: normalizedButtons })
+    }
+
+    const normalizedSections = sanitizeSections(basicSections)
+    if (normalizedSections.length) {
+      components.push({ type: "sections", sections: normalizedSections })
+    }
+
     const templateToSumbit : TemplateModel = {
       companyID: companyId,
-      // Asignamos el mismo valor de nameTemplate al campo name requerido
-      name: data.nameTemplate || '', // Aseguramos que siempre haya un valor
+      name: data.nameTemplate || '',
       nameTemplate: data.nameTemplate,
-      textTemplate: data.textTemplate
+      textTemplate: data.textTemplate,
+      components: components.length ? components : undefined
     }
 
     await save(templateToSumbit)
@@ -153,6 +651,35 @@ const TemplateForm = () => {
       }
     }
     
+    const buttonValidationError = validateButtons(multimediaButtons)
+    if (buttonValidationError) {
+      showError(buttonValidationError)
+      return
+    }
+
+    const sectionsValidationError = validateSections(multimediaSections)
+    if (sectionsValidationError) {
+      showError(sectionsValidationError)
+      return
+    }
+
+    const components: TemplateInteractiveComponent[] = []
+    const trimmedText = data.text?.trim()
+
+    if (trimmedText) {
+      components.push(createBodyComponent(trimmedText))
+    }
+
+    const normalizedButtons = sanitizeButtons(multimediaButtons)
+    if (normalizedButtons.length) {
+      components.push({ type: "buttons", buttons: normalizedButtons })
+    }
+
+    const normalizedSections = sanitizeSections(multimediaSections)
+    if (normalizedSections.length) {
+      components.push({ type: "sections", sections: normalizedSections })
+    }
+
     const multimediaTemplate: MultimediaTemplateModel = {
       companyId: companyId,
       name: data.name,
@@ -162,75 +689,76 @@ const TemplateForm = () => {
       mediaCaption: data.mediaCaption,
       mediaFilename: data.mediaFilename,
       category: data.category || 'MARKETING',
-      language: data.language || 'es'
+      language: data.language || 'es',
+      components: components.length ? components : undefined
     }
-    
+
     await saveMultimedia(multimediaTemplate)
   }
   
   /**
- * Maneja la carga de archivos multimedia al servidor
- * Utiliza el servicio FileUploadService para subir archivos al backend
- * Mantiene compatibilidad con URLs existentes como fallback
- */
-const onFileUpload = async (event: FileUploadHandlerEvent) => {
-try {
-  setBlocked(true); // Bloquear la interfaz durante la carga
-  
-  // Validar que event.files exista y tenga al menos un elemento
-  if (!event.files || !event.files.length) {
-    throw new Error('No se recibió ningún archivo');
+   * Maneja la carga de archivos multimedia al servidor
+   * Utiliza el servicio FileUploadService para subir archivos al backend
+   * Mantiene compatibilidad con URLs existentes como fallback
+   */
+  const onFileUpload = async (event: FileUploadHandlerEvent) => {
+    try {
+      setBlocked(true) // Bloquear la interfaz durante la carga
+
+      // Validar que event.files exista y tenga al menos un elemento
+      if (!event.files || !event.files.length) {
+        throw new Error('No se recibió ningún archivo')
+      }
+
+      const file = event.files[0]
+      console.log('Iniciando carga de archivo:', file.name)
+
+      // Validar que el nombre del archivo sea una cadena
+      const fileName = typeof file.name === 'string' ? file.name : 'archivo'
+
+      // Configuración del subdirectorio para organizar archivos
+      const subDirectory = 'templates'
+
+      try {
+        // Subir el archivo al servidor usando el nuevo servicio
+        const result = await FileUploadService.uploadFile(file, subDirectory)
+
+        console.log('Archivo subido exitosamente:', result)
+
+        // Guardar la URL y el nombre de archivo retornados por el servidor
+        setMediaUrl(result.url)
+        setMediaFileName(result.filename)
+        setValue('mediaUrl', result.url)
+        setValue('mediaFilename', result.filename)
+
+        showSuccess(`Archivo ${fileName} subido correctamente al servidor`)
+      } catch (uploadError) {
+        console.error('Error al subir al servidor, usando fallback de Cloudinary:', uploadError)
+
+        // FALLBACK: Si falla la carga al servidor, usar URL de Cloudinary como respaldo
+        const cloudinaryUrl = 'https://res.cloudinary.com/de6slu8aj/image/upload/v1747428716/cld-sample-5_enrou8.jpg'
+
+        console.log('Usando URL de Cloudinary como fallback:', cloudinaryUrl)
+
+        setMediaUrl(cloudinaryUrl)
+        setMediaFileName(fileName)
+        setValue('mediaUrl', cloudinaryUrl)
+        setValue('mediaFilename', fileName)
+
+        showSuccess('Imagen cargada usando fallback de Cloudinary (el servidor no está disponible)')
+      }
+
+      // Limpiar la referencia del componente FileUpload
+      if (fileUploadRef.current) {
+        (fileUploadRef.current as any).clear()
+      }
+    } catch (error) {
+      console.error('Error general al procesar el archivo:', error)
+      showError(`Error al procesar el archivo: ${(error as Error).message || 'Error desconocido'}`)
+    } finally {
+      setBlocked(false) // Desbloquear la interfaz cuando termine
+    }
   }
-  
-  const file = event.files[0];
-  console.log('Iniciando carga de archivo:', file.name);
-  
-  // Validar que el nombre del archivo sea una cadena
-  const fileName = typeof file.name === 'string' ? file.name : 'archivo';
-  
-  // Configuración del subdirectorio para organizar archivos
-  const subDirectory = 'templates';
-  
-  try {
-    // Subir el archivo al servidor usando el nuevo servicio
-    const result = await FileUploadService.uploadFile(file, subDirectory);
-    
-    console.log('Archivo subido exitosamente:', result);
-    
-    // Guardar la URL y el nombre de archivo retornados por el servidor
-    setMediaUrl(result.url);
-    setMediaFileName(result.filename);
-    setValue('mediaUrl', result.url);
-    setValue('mediaFilename', result.filename);
-    
-    showSuccess(`Archivo ${fileName} subido correctamente al servidor`);
-  } catch (uploadError) {
-    console.error('Error al subir al servidor, usando fallback de Cloudinary:', uploadError);
-    
-    // FALLBACK: Si falla la carga al servidor, usar URL de Cloudinary como respaldo
-    const cloudinaryUrl = 'https://res.cloudinary.com/de6slu8aj/image/upload/v1747428716/cld-sample-5_enrou8.jpg';
-    
-    console.log('Usando URL de Cloudinary como fallback:', cloudinaryUrl);
-    
-    setMediaUrl(cloudinaryUrl);
-    setMediaFileName(fileName);
-    setValue('mediaUrl', cloudinaryUrl);
-    setValue('mediaFilename', fileName);
-    
-    showSuccess(`Imagen cargada usando fallback de Cloudinary (el servidor no está disponible)`); 
-  }
-  
-  // Limpiar la referencia del componente FileUpload
-  if (fileUploadRef.current) {
-    (fileUploadRef.current as any).clear();
-  }
-} catch (error) {
-  console.error('Error general al procesar el archivo:', error);
-  showError(`Error al procesar el archivo: ${(error as Error).message || 'Error desconocido'}`);
-} finally {
-  setBlocked(false); // Desbloquear la interfaz cuando termine
-}
-}
   
   /**
    * Maneja el cambio de tipo de medio
@@ -364,6 +892,27 @@ try {
                     />
                     {basicErrors.textTemplate && <Message severity="error" text={basicErrors.textTemplate.message} />}
                   </div>
+
+                  <ButtonsEditor
+                    title="Botones interactivos"
+                    description="Configure botones para respuestas rápidas, enlaces o llamadas."
+                    buttons={basicButtons}
+                    onAdd={addBasicButton}
+                    onRemove={removeBasicButton}
+                    onChange={updateBasicButton}
+                  />
+
+                  <SectionsEditor
+                    title="Listas (secciones)"
+                    description="Agrupe elementos para menús interactivos dentro de WhatsApp."
+                    sections={basicSections}
+                    onAddSection={addBasicSection}
+                    onRemoveSection={removeBasicSection}
+                    onSectionTitleChange={updateBasicSectionTitle}
+                    onAddRow={addRowToBasicSection}
+                    onRemoveRow={removeRowFromBasicSection}
+                    onRowChange={updateBasicSectionRow}
+                  />
                 </div>
               </TabPanel>
               
@@ -488,6 +1037,31 @@ className="w-full"
                         />
                         {multimediaErrors.text && <Message severity="error" text={multimediaErrors.text.message} />}
                       </div>
+                    </div>
+
+                    <div className="col-12">
+                      <ButtonsEditor
+                        title="Botones interactivos"
+                        description="Añada botones que acompañarán la plantilla multimedia."
+                        buttons={multimediaButtons}
+                        onAdd={addMultimediaButton}
+                        onRemove={removeMultimediaButton}
+                        onChange={updateMultimediaButton}
+                      />
+                    </div>
+
+                    <div className="col-12">
+                      <SectionsEditor
+                        title="Listas (secciones)"
+                        description="Cree menús tipo lista para la plantilla multimedia."
+                        sections={multimediaSections}
+                        onAddSection={addMultimediaSection}
+                        onRemoveSection={removeMultimediaSection}
+                        onSectionTitleChange={updateMultimediaSectionTitle}
+                        onAddRow={addRowToMultimediaSection}
+                        onRemoveRow={removeRowFromMultimediaSection}
+                        onRowChange={updateMultimediaSectionRow}
+                      />
                     </div>
 
                     {/* Campos de categoría e idioma */}

--- a/shared/models/template/index.ts
+++ b/shared/models/template/index.ts
@@ -1,1 +1,2 @@
 export * from "./template.model"
+export * from "./multimedia-template.model"

--- a/shared/models/template/multimedia-template.model.ts
+++ b/shared/models/template/multimedia-template.model.ts
@@ -1,3 +1,5 @@
+import { TemplateInteractiveComponent } from "./template.model"
+
 /**
  * Tipos de medios soportados para plantillas multimedia
  */
@@ -57,4 +59,9 @@ export interface MultimediaTemplateModel {
    * Texto principal del mensaje
    */
   text: string;
+
+  /**
+   * Componentes interactivos de la plantilla multimedia
+   */
+  components?: TemplateInteractiveComponent[];
 }

--- a/shared/models/template/template.model.ts
+++ b/shared/models/template/template.model.ts
@@ -1,3 +1,80 @@
+export type TemplateButtonType = "QUICK_REPLY" | "URL" | "PHONE_NUMBER";
+
+export interface TemplateButton {
+  /**
+   * Identificador opcional del botón (solo para uso en frontend)
+   */
+  id?: string;
+
+  /**
+   * Tipo de botón soportado por las plantillas de WhatsApp
+   */
+  type: TemplateButtonType;
+
+  /**
+   * Texto visible del botón
+   */
+  text: string;
+
+  /**
+   * Payload opcional (para respuestas rápidas)
+   */
+  payload?: string;
+
+  /**
+   * URL opcional (para botones de tipo URL)
+   */
+  url?: string;
+
+  /**
+   * Número telefónico opcional (para botones de llamada)
+   */
+  phoneNumber?: string;
+}
+
+export type TemplateComponentParameter =
+  | { type: "text"; text: string }
+  | { type: "payload"; payload: string };
+
+export interface TemplateSectionRow {
+  id?: string;
+  title: string;
+  description?: string;
+}
+
+export interface TemplateSection {
+  id?: string;
+  title: string;
+  rows: TemplateSectionRow[];
+}
+
+export interface TemplateBodyComponent {
+  type: "body";
+  text?: string;
+  parameters?: TemplateComponentParameter[];
+}
+
+export interface TemplateFooterComponent {
+  type: "footer";
+  text: string;
+}
+
+export interface TemplateButtonsComponent {
+  type: "buttons";
+  buttons: TemplateButton[];
+}
+
+export interface TemplateSectionsComponent {
+  type: "sections";
+  sections: TemplateSection[];
+}
+
+export type TemplateInteractiveComponent =
+  | TemplateBodyComponent
+  | TemplateFooterComponent
+  | TemplateButtonsComponent
+  | TemplateSectionsComponent;
+
 export interface TemplateModel {
   id?: number;
   companyID?: number;
@@ -6,4 +83,8 @@ export interface TemplateModel {
   textTemplate?: string;   // Campo anterior - para compatibilidad
   categoryTemplateWhatsapp?: string;  // Categoría de la plantilla (MARKETING, etc.)
   statusTemplateWhatsapp?: string;    // Estado de la plantilla (APPROVED, PENDING)
+  /**
+   * Componentes interactivos asociados a la plantilla
+   */
+  components?: TemplateInteractiveComponent[];
 }

--- a/shared/services/template/template.service.ts
+++ b/shared/services/template/template.service.ts
@@ -32,8 +32,8 @@ const TemplateService = {
    */
   saveMultimedia: async (multimediaTemplate: MultimediaTemplateModel) => {
     try {
-      const response = await axios.post<TemplateModel>(
-        `${templateEndpoint}/multimedia`, 
+      const response = await axios.post<MultimediaTemplateModel>(
+        `${templateEndpoint}/multimedia`,
         multimediaTemplate
       );
       return response;


### PR DESCRIPTION
## Summary
- define los tipos de botones, secciones y componentes interactivos y los expone para plantillas básicas y multimedia
- añade controles en el formulario de plantillas para configurar botones/listas y enviar los componentes al backend
- construye los componentes de cuerpo y botones al disparar mensajes de plantilla de WhatsApp, respetando el formato de la Graph API

## Testing
- pnpm lint *(falla: el repositorio contiene numerosas infracciones de ESLint preexistentes)*

------
https://chatgpt.com/codex/tasks/task_e_68d86e2e5554833295320024be81cfc2